### PR TITLE
Update shebang to use system default installation for zsh (MacOS) [COSMIC-123]

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ After the script successfully run, you can access each services at:
 - **React**: [cosmic.localhost](http://cosmic.localhost)
 - **FastAPI**: [api.cosmic.localhost](http://api.cosmic.localhost)
 - **pgAdmin**: [db.cosmic.localhost](http://db.cosmic.localhost) (Use the credentials from `docker/secrets/gui/pgadmin_*.txt` file to log in)
-- **Ollama**: [ollama.cosmic.localhost](http://ollama.cosmic.localhost)
 - **PostgreSQL**: To access the database directly from the command line, use:
 
 ```bash
@@ -90,7 +89,6 @@ After the script successfully run, you can access each services at:
 - **React**: [cosmic.localhost](http://cosmic.localhost)
 - **FastAPI**: [api.cosmic.localhost](http://api.cosmic.localhost)
 - **pgAdmin**: [db.cosmic.localhost](http://db.cosmic.localhost) (Use the credentials from `docker/secrets/gui/pgadmin_*.txt` file to log in)
-- **Ollama**: [ollama.cosmic.localhost](http://ollama.cosmic.localhost)
 - **PostgreSQL**: To access the database directly from the command line, use:
 
 ```bash

--- a/backend/README.md
+++ b/backend/README.md
@@ -181,9 +181,7 @@ Once the containers are running, you can verify that all services are working co
 
 3. **pgAdmin**: The database management tool is accessible at [db.cosmic.localhost](http://db.cosmic.localhost). Use the credentials from your `docker/secrets/gui/pgadmin_*.txt` file to log in.
 
-4. **Ollama**: The Ollama models are accessible at [ollama.cosmic.localhost](http://ollama.cosmic.localhost). This endpoint allows you to interact with Ollama models directly without having to write code in the backend services.
-
-5. **PostgreSQL**: To access the database directly from the command line, use:
+4. **PostgreSQL**: To access the database directly from the command line, use:
 
 ```bash
 # On Linux/MacOS, add `sudo` if necessary
@@ -244,11 +242,9 @@ You can now verify that the backend is running correctly:
 
 2. **FastAPI**: The REST API (Swagger) is served at [api.cosmic.localhost](http://api.cosmic.localhost). This endpoint provides interactive API documentation where you can test endpoints directly from your browser.
 
-3. **pgAdmin**:
+4. **pgAdmin**:
 - On Windows or macOS, search for and open the **pgAdmin 4** application from your applications menu.
 - On Linux, search for pgAdmin or type `pgadmin4` in your terminal to start the application.
-
-4. **Ollama**: The Ollama models are accessible at [ollama.cosmic.localhost](http://ollama.cosmic.localhost). This endpoint allows you to interact with Ollama models directly without having to write code in the backend services.
 
 5. **PostgreSQL**: To verify that your PostgreSQL connection is working, open a terminal and connect to the database:
 

--- a/doc/GIT.md
+++ b/doc/GIT.md
@@ -6,3 +6,4 @@ We encourage everyone to follow the [Conventional Commit](https://www.convention
 3. `exp`: for experiment changes during short deadlines in sub-branch ONLY.
 4. `refactor`: for updating current code style without breaking any working logics.
 5. `feat`: for adding new feature to the code. For example, new api for a new microservice.
+6. `cli`: for changes to shell scripts or CLI script.

--- a/scripts/demos/cosmic_demo.zsh
+++ b/scripts/demos/cosmic_demo.zsh
@@ -1,4 +1,4 @@
-#!/usr/bin/env zsh
+#!/bin/zsh
 
 
 ################################################################################
@@ -11,18 +11,18 @@
 #              with filename cleaning.
 #
 # @usage
-#   ./cosmic_demo.sh
-#   LOG_LEVEL=1 ./cosmic_demo.sh
+#   ./cosmic_demo.zsh
+#   LOG_LEVEL=1 ./cosmic_demo.zsh
 #
 # @examples
 #   # Run with default INFO logging
-#   ./cosmic_demo.sh
+#   ./cosmic_demo.zsh
 #
 #   # Run with WARNING level (less verbose)
-#   LOG_LEVEL=1 ./cosmic_demo.sh
+#   LOG_LEVEL=1 ./cosmic_demo.zsh
 #
 #   # Run with ERROR level (most verbose)
-#   LOG_LEVEL=2 ./cosmic_demo.sh
+#   LOG_LEVEL=2 ./cosmic_demo.zsh
 #
 # @env LOG_LEVEL (optional) Sets the logging verbosity (0=INFO, 1=WARNING, 2=ERROR)
 #


### PR DESCRIPTION
I've also update main README to address the removal of public access to Ollama service. I forget to do this in PR from COSMIC-116 ticket to `bing-dev` branch. Oh, and we have a new sementic tag for CLI-related scripts update as well.