### PR TITLE
chore: better naming for the API tags

### DIFF
--- a/api.py
+++ b/api.py
@@ -38,5 +38,5 @@ app.add_middleware(
 )
 
 # APIs - smanile
-app.include_router(default_apis.router, tags=["Default APIs"])
-app.include_router(models.router, prefix="/api/v1/models", tags=["Models APIs"])
+app.include_router(default_apis.router, tags=["CoSMIC APIs"])
+app.include_router(models.router, prefix="/api/v1/models", tags=["Ollama Models APIs"])


### PR DESCRIPTION
# APIs - smanile
app.include_router(default_apis.router, tags=["CoSMIC APIs"])
app.include_router(models.router, prefix="/api/v1/models", tags=["Ollama Models APIs"])

Edit the tag names. It seems have no implications with the code functionality. 
