### PR TITLE
chore: ensure the network has the same name in all compose.

### DIFF
--- a/docker-compose.postgres.yaml
+++ b/docker-compose.postgres.yaml
@@ -163,4 +163,5 @@ volumes:
 
 networks:
   cosmic_net:
+    name: cosmic_net
     driver: bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   ollama:
     image: ollama/ollama:latest
-    container_name: ollama
+    container_name: ollama_cosmic
     deploy:
       resources:
         reservations:
@@ -89,4 +89,5 @@ volumes:
 
 networks:
   cosmic_net:
+    name: cosmic_net
     driver: bridge


### PR DESCRIPTION
Just add network name into the docker compose files to ensure all containers has the same network. 