### PR TITLE
bug:fix statistic file that was causing api to crash and issue 109

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,13 @@ services:
     build:
       context: ./
       dockerfile: ./docker/dockerfiles/fastapi.Dockerfile
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
     volumes:
       # - type: volume
       #   source: open-webui
@@ -67,9 +74,9 @@ services:
     tty: true
     # NOTE: For quick debugging (on dev only)
     ports:
-      - name: cosmic-uvicorn
+      - name: cosmic-fastapi
         target: 3000
-        host_ip: 127.0.0.1
+        # host_ip: 127.0.0.1
         published: "3000"
         protocol: tcp
         app_protocol: http
@@ -77,7 +84,7 @@ services:
 
       - name: cosmic-debugpy
         target: 5678
-        host_ip: 127.0.0.1
+        # host_ip: 127.0.0.1
         published: "5678"
         protocol: tcp
         app_protocol: http

--- a/docker/dockerfiles/fastapi.Dockerfile
+++ b/docker/dockerfiles/fastapi.Dockerfile
@@ -31,4 +31,5 @@ EXPOSE 3000/tcp
 # TODO:
 # provide `--no-reload` flag on production run, change the `--host` flag, and
 # remove `dev` flag on prod run.
-CMD [ "uv", "run", "fastapi", "dev", "api.py", "--host", "0.0.0.0", "--port", "3000" ]
+# CMD [ "uv", "run", "fastapi", "dev", "api.py", "--host", "0.0.0.0", "--port", "3000" ]
+CMD [ "uv", "run", "uvicorn", "api:app", "--host", "0.0.0.0", "--port", "3000", "--reload" ]

--- a/utils/statistics.py
+++ b/utils/statistics.py
@@ -24,7 +24,7 @@ def update_statistic_table(statistic_dict):
     )
 
     if os.path.exists(statistic_path):
-        data = pd.read_csv(statistic_path)
+        data = pd.read_csv(statistic_path, dtype={"average_token_length": float})
         user_emails = data["email"].tolist()
     else:
         user_emails = []


### PR DESCRIPTION
Fixed the issue with the statistics
using uvicorn instead of fastapi CLI, to avoid the bad printing
Fixed issue #109 