### PR TITLE
add: upload files into the chat_session_memory

### DIFF
--- a/api.py
+++ b/api.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 
 ### Internal modules ###
-from .backend.routers import default_apis, models, cosmic
+from .backend.routers import default_apis, models, cosmic, chat_session_memory
 
 # =====================Debugging========================
 # Uncomment the following lines to enable debugging
@@ -47,3 +47,8 @@ app.add_middleware(
 app.include_router(default_apis.router, tags=["CoSMIC APIs"])
 app.include_router(models.router, prefix="/api/v1/models", tags=["Ollama Models APIs"])
 app.include_router(cosmic.router, prefix="/api/v1/cosmic", tags=["CoSMIC - V1"])
+app.include_router(
+    chat_session_memory.router,
+    prefix="/api/v1",
+    tags=["Upload Files - chat session memory"],
+)

--- a/backend/routers/chat_session_memory.py
+++ b/backend/routers/chat_session_memory.py
@@ -1,0 +1,36 @@
+import uuid
+from fastapi import APIRouter, UploadFile
+from pathlib import Path
+
+router = APIRouter()
+
+
+@router.post("/upload")
+async def upload_file(
+    file: UploadFile, chat_session_id: str = "default", user_id: str = "default"
+):
+
+    file_id = uuid.uuid4().hex[:8]
+
+    # create a path
+    save_dir = Path(f"/app/data/chat_session_memory/{user_id}/{chat_session_id}")
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    # combine path + file name -> example: Path("/app/data/chat_session_memory/123/manile.pdf")
+    file_path = save_dir / f"{file_id}_{file.filename}"
+
+    # then read the file
+    content = await file.read()
+
+    # then creates folder and open it
+    f = open(file_path, "wb")
+    # then write content
+    f.write(content)
+    f.close()
+
+    return {
+        "file_id": file_id,
+        "file_name": file.filename,
+        "file_path": str(file_path),
+        "content_type": file.content_type,
+    }


### PR DESCRIPTION
Hi @marslanshaukat, 

this is the simple upload file into the chat_session_memory api, just upload file, then the api will create path, read the file and then write the content into the folder based on the path. 

- we still need to further develop it like file size limit, file type, ... ; however, i think it is basic enough for you to continue the task cosmic-227 

- i have checked the docker container already, the file uploaded is in there