### PR TITLE
Update FastAPI's title name to better differentiate `/docs` page for CoSMIC Internal API & CoSMIC Database API [COSMIC-266]

### DIFF
--- a/api.py
+++ b/api.py
@@ -85,7 +85,10 @@ async def lifespan(app: FastAPI):
     app.state.opensi_cosmic.quit()
 
 
-cosmic_app: FastAPI = FastAPI(lifespan=lifespan)
+cosmic_app: FastAPI = FastAPI(
+    lifespan=lifespan,
+    title="CoSMIC Internal API"
+)
 
 
 CORS_ALLOW_ORIGIN = [


### PR DESCRIPTION
*Ref: [COSMIC-266 Ticket](https://opensi.atlassian.net/browse/COSMIC-266)*


**Extra information besides what have been explained in ticket:**

1. **[Metadata and Docs URLs - FastAPI](https://fastapi.tiangolo.com/tutorial/metadata/)**
2. **[Method to just override default `<title>` tag value](https://stackoverflow.com/questions/71426765/how-to-remove-swagger-ui-from-html-page-title-of-openapi-docs-in-fastapi)**