### PR TITLE
CoSMIC 331: Session clean

### DIFF
--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -7,6 +7,8 @@ from fastapi import (
     HTTPException
 )
 from pathlib import Path
+import logging
+import shutil
 
 
 ### Type hints ###
@@ -14,22 +16,24 @@ from ...types.tags import APITag
 import mimetypes
 import os
 
-from ...src.services.document_index import DocumentMetadata, compute_content_hash
+from ...src.services.document_index import DocumentIndex, DocumentMetadata, compute_content_hash
 
 router = APIRouter()
+
+logger = logging.getLogger(__name__)
 
 # Embeddable file types
 EMBEDDABLE_EXTENSIONS = {".pdf"}
 
 # Global and User document index instances
 # These will be set by the cosmic router initialization
-_global_document_index = None
-_user_document_index = None
+_global_document_index: DocumentIndex = None
+_user_document_index: DocumentIndex = None
 # Vector database to embed uploaded files
 _vector_database = None
 
 
-def set_document_indexes(global_index, user_index):
+def set_document_indexes(global_index: DocumentIndex, user_index: DocumentIndex) -> None:
     """Initialize document indexes (called by cosmic router)"""
     global _global_document_index, _user_document_index
     _global_document_index = global_index
@@ -150,3 +154,45 @@ async def upload_file(
         "content_type": file.content_type,
         "chunk_count": chunk_count,
     }
+
+
+@router.delete(
+    path="/session/{chat_session_id}",
+    status_code=status.HTTP_200_OK,
+)
+async def delete_session_data(chat_session_id: str):
+    """
+    Receiver for chat-session deletion. Called clicking the 
+    "delete chat" action, so CoSMIC can drop the on-disk files
+    and document-index metadata it holds for that session_id.
+    """
+    docs = _user_document_index.get_documents_by_session(chat_session_id) \
+        if _user_document_index \
+            else []
+
+    user_ids = {doc.user_id for doc in docs if doc.user_id} # this would ideally be 0
+
+    deleted_files = 0
+    failed_paths: list[str] = []
+
+    for user_id in user_ids:
+        session_dir = Path(f"/app/data/memories/users/{user_id}/sessions/{chat_session_id}")
+
+        if not session_dir.exists():
+            continue
+
+        try:
+            file_count = sum(1 for p in session_dir.rglob("*") if p.is_file())
+            shutil.rmtree(session_dir)
+            deleted_files += file_count
+            logger.info(
+                f"Deleted session directory {session_dir} ({file_count} files) "
+                f"for session_id = {chat_session_id}"
+            )
+
+        except OSError as exc:
+            failed_paths.append(str(session_dir))
+            logger.error(
+                f"Failed to delete session directory {session_dir} "
+                f"for session_id = {chat_session_id}: {exc}"
+            )

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -203,7 +203,7 @@ async def delete_session_data(request: SessionDeleteRequest) -> dict:
             deleted_files += file_count
             print(
                 set_color(
-                    staus = "info", 
+                    status = "info", 
                     information = (f"Deleted session directory {session_dir} ({file_count} files) "
                                    f"for session_id = {chat_session_id}")
                 )
@@ -213,7 +213,7 @@ async def delete_session_data(request: SessionDeleteRequest) -> dict:
             failed_paths.append(str(session_dir))
             print(
                 set_color(
-                    staus = "error", 
+                    status = "error", 
                     information = (f"Failed to delete session directory {session_dir} "
                                    f"for session_id = {chat_session_id}: {exc}")
                 )
@@ -231,7 +231,7 @@ async def delete_session_data(request: SessionDeleteRequest) -> dict:
             vectors_deleted_count = _vector_database.delete_by_session_id(chat_session_id)
             print(
                 set_color(
-                    staus = "info", 
+                    status = "info", 
                     information = (f"Deleted {vectors_deleted_count} vector(s) from Qdrant "
                                    f"for session_id = {chat_session_id}")
                 )
@@ -240,7 +240,7 @@ async def delete_session_data(request: SessionDeleteRequest) -> dict:
             vector_cleanup_failed = True
             print(
                 set_color(
-                    staus = "error", 
+                    status = "error", 
                     information = (f"Failed to delete vectors for session_id = {chat_session_id}: {exc}")
                 )
             )
@@ -248,7 +248,7 @@ async def delete_session_data(request: SessionDeleteRequest) -> dict:
     success = not failed_paths and not vector_cleanup_failed
     print(
         set_color(
-            staus = "info", 
+            status = "info", 
             information = (f"Session cleanup for session_id = {chat_session_id}: "
                            f"files_deleted = {deleted_files}, metadata_removed = {removed_docs}, "
                            f"vectors_deleted_count = {vectors_deleted_count}, failed_paths = {failed_paths}, "

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -160,11 +160,22 @@ async def upload_file(
     path="/session/{chat_session_id}",
     status_code=status.HTTP_200_OK,
 )
-async def delete_session_data(chat_session_id: str):
+async def delete_session_data(chat_session_id: str) -> dict:
     """
     Receiver for chat-session deletion. Called clicking the 
     "delete chat" action, so CoSMIC can drop the on-disk files
     and document-index metadata it holds for that session_id.
+
+    Args:
+        chat_session_id (str): The chat session to delete.
+
+    Returns:
+        dict: A dictionary with:
+            - Success bool
+            - Session id
+            - The number of files deleted, 
+            - The number of metadata removed, and 
+            - A list of failed paths.
     """
     docs = _user_document_index.get_documents_by_session(chat_session_id) \
         if _user_document_index \

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -8,7 +8,6 @@ from fastapi import (
 )
 from pathlib import Path
 from pydantic import BaseModel
-import logging
 import shutil
 
 
@@ -19,10 +18,9 @@ import os
 
 from ...src.services.document_index import DocumentIndex, DocumentMetadata, compute_content_hash
 from ...src.services.vector_database import VectorDatabase
+from ...utils.log_tool import set_color
 
 router = APIRouter()
-
-logger = logging.getLogger(__name__)
 
 # Embeddable file types
 EMBEDDABLE_EXTENSIONS = {".pdf"}
@@ -203,16 +201,22 @@ async def delete_session_data(request: SessionDeleteRequest) -> dict:
             file_count = sum(1 for p in session_dir.rglob("*") if p.is_file())
             shutil.rmtree(session_dir)
             deleted_files += file_count
-            logger.info(
-                f"Deleted session directory {session_dir} ({file_count} files) "
-                f"for session_id = {chat_session_id}"
+            print(
+                set_color(
+                    staus = "info", 
+                    information = (f"Deleted session directory {session_dir} ({file_count} files) "
+                                   f"for session_id = {chat_session_id}")
+                )
             )
 
         except OSError as exc:
             failed_paths.append(str(session_dir))
-            logger.error(
-                f"Failed to delete session directory {session_dir} "
-                f"for session_id = {chat_session_id}: {exc}"
+            print(
+                set_color(
+                    staus = "error", 
+                    information = (f"Failed to delete session directory {session_dir} "
+                                   f"for session_id = {chat_session_id}: {exc}")
+                )
             )
 
     removed_docs = 0
@@ -225,22 +229,31 @@ async def delete_session_data(request: SessionDeleteRequest) -> dict:
     if _vector_database is not None:
         try:
             vectors_deleted_count = _vector_database.delete_by_session_id(chat_session_id)
-            logger.info(
-                f"Deleted {vectors_deleted_count} vector(s) from Qdrant "
-                f"for session_id = {chat_session_id}"
+            print(
+                set_color(
+                    staus = "info", 
+                    information = (f"Deleted {vectors_deleted_count} vector(s) from Qdrant "
+                                   f"for session_id = {chat_session_id}")
+                )
             )
         except Exception as exc:
             vector_cleanup_failed = True
-            logger.error(
-                f"Failed to delete vectors for session_id = {chat_session_id}: {exc}"
+            print(
+                set_color(
+                    staus = "error", 
+                    information = (f"Failed to delete vectors for session_id = {chat_session_id}: {exc}")
+                )
             )
 
     success = not failed_paths and not vector_cleanup_failed
-    logger.info(
-        f"Session cleanup for session_id = {chat_session_id}: "
-        f"files_deleted = {deleted_files}, metadata_removed = {removed_docs}, "
-        f"vectors_deleted_count = {vectors_deleted_count}, failed_paths = {failed_paths}, "
-        f"vector_cleanup_failed = {vector_cleanup_failed}"
+    print(
+        set_color(
+            staus = "info", 
+            information = (f"Session cleanup for session_id = {chat_session_id}: "
+                           f"files_deleted = {deleted_files}, metadata_removed = {removed_docs}, "
+                           f"vectors_deleted_count = {vectors_deleted_count}, failed_paths = {failed_paths}, "
+                           f"vector_cleanup_failed = {vector_cleanup_failed}")
+        )
     )
 
     return {

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -196,3 +196,23 @@ async def delete_session_data(chat_session_id: str):
                 f"Failed to delete session directory {session_dir} "
                 f"for session_id = {chat_session_id}: {exc}"
             )
+
+    removed_docs = 0
+    for doc in docs:
+        if _user_document_index.remove_document(doc.document_id):
+            removed_docs += 1
+
+    success = not failed_paths
+    logger.info(
+        f"Session cleanup for session_id = {chat_session_id}: "
+        f"files_deleted = {deleted_files}, metadata_removed = {removed_docs}, "
+        f"failed_paths = {failed_paths}"
+    )
+
+    return {
+        "success": success,
+        "session_id": chat_session_id,
+        "files_deleted_count": deleted_files,
+        "metadata_removed_count": removed_docs,
+        "failed_paths": failed_paths,
+    }

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -7,6 +7,7 @@ from fastapi import (
     HTTPException
 )
 from pathlib import Path
+from pydantic import BaseModel
 import logging
 import shutil
 
@@ -17,6 +18,7 @@ import mimetypes
 import os
 
 from ...src.services.document_index import DocumentIndex, DocumentMetadata, compute_content_hash
+from ...src.services.vector_database import VectorDatabase
 
 router = APIRouter()
 
@@ -30,7 +32,7 @@ EMBEDDABLE_EXTENSIONS = {".pdf"}
 _global_document_index: DocumentIndex = None
 _user_document_index: DocumentIndex = None
 # Vector database to embed uploaded files
-_vector_database = None
+_vector_database: VectorDatabase = None
 
 
 def set_document_indexes(global_index: DocumentIndex, user_index: DocumentIndex) -> None:
@@ -156,42 +158,47 @@ async def upload_file(
     }
 
 
-@router.delete(
-    path="/session/{chat_session_id}",
+class SessionDeleteRequest(BaseModel):
+    chat_id: str
+    user_id: str
+
+
+@router.post(
+    path="/session/delete",
     status_code=status.HTTP_200_OK,
 )
-async def delete_session_data(chat_session_id: str) -> dict:
+async def delete_session_data(request: SessionDeleteRequest) -> dict:
     """
-    Receiver for chat-session deletion. Called clicking the 
-    "delete chat" action, so CoSMIC can drop the on-disk files
-    and document-index metadata it holds for that session_id.
+    Receiver for chat-session deletion. Called when the user clicks the
+    "delete chat" action, so CoSMIC can drop the on-disk files, the
+    document-index metadata, and the vectors it holds for that session_id.
 
     Args:
-        chat_session_id (str): The chat session to delete.
+        request (SessionDeleteRequest): chat_id and user_id of the deleted session.
 
     Returns:
         dict: A dictionary with:
             - Success bool
             - Session id
-            - The number of files deleted, 
-            - The number of metadata removed, and 
-            - A list of failed paths.
+            - The number of files deleted,
+            - The number of metadata removed,
+            - The number of vectors deleted,
+            - A list of failed paths, and
+            - Whether vector cleanup failed.
     """
+    chat_session_id = request.chat_id
+    user_id = request.user_id
+
     docs = _user_document_index.get_documents_by_session(chat_session_id) \
         if _user_document_index \
             else []
 
-    user_ids = {doc.user_id for doc in docs if doc.user_id} # this would ideally be 0
-
     deleted_files = 0
     failed_paths: list[str] = []
 
-    for user_id in user_ids:
-        session_dir = Path(f"/app/data/memories/users/{user_id}/sessions/{chat_session_id}")
+    session_dir = Path(f"/app/data/memories/users/{user_id}/sessions/{chat_session_id}")
 
-        if not session_dir.exists():
-            continue
-
+    if session_dir.exists():
         try:
             file_count = sum(1 for p in session_dir.rglob("*") if p.is_file())
             shutil.rmtree(session_dir)
@@ -213,11 +220,27 @@ async def delete_session_data(chat_session_id: str) -> dict:
         if _user_document_index.remove_document(doc.document_id):
             removed_docs += 1
 
-    success = not failed_paths
+    vectors_deleted_count = 0
+    vector_cleanup_failed = False
+    if _vector_database is not None:
+        try:
+            vectors_deleted_count = _vector_database.delete_by_session_id(chat_session_id)
+            logger.info(
+                f"Deleted {vectors_deleted_count} vector(s) from Qdrant "
+                f"for session_id = {chat_session_id}"
+            )
+        except Exception as exc:
+            vector_cleanup_failed = True
+            logger.error(
+                f"Failed to delete vectors for session_id = {chat_session_id}: {exc}"
+            )
+
+    success = not failed_paths and not vector_cleanup_failed
     logger.info(
         f"Session cleanup for session_id = {chat_session_id}: "
         f"files_deleted = {deleted_files}, metadata_removed = {removed_docs}, "
-        f"failed_paths = {failed_paths}"
+        f"vectors_deleted_count = {vectors_deleted_count}, failed_paths = {failed_paths}, "
+        f"vector_cleanup_failed = {vector_cleanup_failed}"
     )
 
     return {
@@ -225,5 +248,7 @@ async def delete_session_data(chat_session_id: str) -> dict:
         "session_id": chat_session_id,
         "files_deleted_count": deleted_files,
         "metadata_removed_count": removed_docs,
+        "vectors_deleted_count_count": vectors_deleted_count,
         "failed_paths": failed_paths,
+        "vector_cleanup_failed": vector_cleanup_failed,
     }

--- a/src/services/vector_database.py
+++ b/src/services/vector_database.py
@@ -301,6 +301,40 @@ class VectorDatabase(ServiceBase):
             )
             return 0
 
+
+    def delete_by_session_id(self, session_id: str) -> int:
+        """ 
+        Remove all vector points belonging to a chat session.
+        Scoped strictly to `metadata.session_id == session_id`, so other
+        sessions' vectors are left untouched. Unlike `delete_by_document_id`,
+        this does not swallow errors - callers are expected to handle/log
+        failures themselves.
+
+        Returns:
+            int: number of points deleted.
+        """
+        session_filter = models.Filter(
+            must = [models.FieldCondition(key = "metadata.session_id",
+                                          match=models.MatchValue(value=session_id))]
+        )
+
+        point_count = self.database.client.count(
+            collection_name=self.database.collection_name,
+            count_filter=session_filter,
+            exact=True,
+        ).count
+
+        if point_count == 0:
+            return 0
+
+        self.database.client.delete(
+            collection_name=self.database.collection_name,
+            points_selector=models.FilterSelector(filter=session_filter),
+        )
+
+        return point_count
+
+
     def delete_by_document_id(self, document_id: str) -> None:
         """ Remove all vector points belonging to a document to avoid stale chunks """
         try:


### PR DESCRIPTION
The UI now sends a post request to CoSMIC with user ID and chat ID. We then use those to create the directory path where session files are usually located. subsequently, we clean up the document index JSON file and the vector database. Logs using print statements.